### PR TITLE
Implement playercount placeholders

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoExtensionProxy/AkzuwoExtensionProxy.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoExtensionProxy/AkzuwoExtensionProxy.java
@@ -1,18 +1,71 @@
 package ch.ksrminecraft.akzuwoExtensionProxy;
 
 import com.google.inject.Inject;
-import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
+import ch.ksrminecraft.akzuwoExtensionProxy.PlaceholderProvider;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+/**
+ * Main plugin class and provider for custom placeholders.
+ */
 
 @Plugin(id = "akzuwoextensionproxy", name = "AkzuwoExtensionProxy", version = "1.0")
-public class AkzuwoExtensionProxy {
+public class AkzuwoExtensionProxy implements PlaceholderProvider {
 
     @Inject
     private Logger logger;
 
+    @Inject
+    private ProxyServer proxy;
+
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
+        logger.info("AkzuwoExtensionProxy initialized");
+        // Register this class as a simple placeholder provider so other plugins
+        // can access the placeholders via the Velocity ServiceManager.
+        proxy.getServiceManager().register(this, PlaceholderProvider.class, this);
+    }
+
+    /**
+     * Returns the value of the custom placeholders.
+     *
+     * @param placeholder Placeholder identifier
+     * @return replacement or {@code null} if unknown
+     */
+    public String getPlaceholderValue(String placeholder) {
+        switch (placeholder.toLowerCase()) {
+            case "%akzuwoextensionproxy_playercount%":
+                return String.valueOf(proxy.getPlayerCount());
+            case "%akzuwoextensionproxy_playercount_vanish%":
+                return String.valueOf(getVisiblePlayerCount());
+            default:
+                return null;
+        }
+    }
+
+    private int getVisiblePlayerCount() {
+        int vanished = 0;
+        try {
+            Class<?> apiClass = Class.forName("de.myzelyam.api.vanish.VanishAPI");
+            Method isInvisible = apiClass.getMethod("isInvisible", UUID.class);
+            for (Player player : proxy.getAllPlayers()) {
+                boolean invisible = (boolean) isInvisible.invoke(null, player.getUniqueId());
+                if (invisible) {
+                    vanished++;
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            logger.warn("PremiumVanish API not found. Placeholder will include all players.");
+        } catch (Exception e) {
+            logger.error("Failed to query PremiumVanish API", e);
+        }
+        return proxy.getPlayerCount() - vanished;
     }
 }

--- a/src/main/java/ch/ksrminecraft/akzuwoExtensionProxy/PlaceholderProvider.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoExtensionProxy/PlaceholderProvider.java
@@ -1,0 +1,16 @@
+package ch.ksrminecraft.akzuwoExtensionProxy;
+
+/**
+ * Simple service interface that allows other plugins to request
+ * the custom placeholder values provided by this plugin.
+ */
+public interface PlaceholderProvider {
+
+    /**
+     * Resolve the value for a placeholder.
+     *
+     * @param placeholder placeholder identifier
+     * @return resolved value or {@code null} if the placeholder is unknown
+     */
+    String getPlaceholderValue(String placeholder);
+}


### PR DESCRIPTION
## Summary
- add simple placeholder service interface
- register placeholders for online players and visible players

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68502b1e0e108325972a7c18efc7d8c7